### PR TITLE
readme: fix link to app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # coperformance
 New York Philharmonic and Social Network Analysis
 
-This repository contains the code neccessary to run the coperformance app that's on my shiny server at overthinkdciscores.com/coperformance, except for two things:
+This repository contains the code neccessary to run the coperformance app that's on my shiny server at https://overthinkdciapps.com/coperformance/, except for two things:
 1. The New York Philharmonic program history, which you can get yourself at their repository
 2. The gcc compiled Go/C code PhilProcess.so, which can be compiled with the go code in the nyphil folder


### PR DESCRIPTION
https://overthinkdciscores.com/coperformance results in 404, and the blog posts links to https://overthinkdciapps.com/coperformance/ which works